### PR TITLE
FIX: KeyError when p_cut > len(labels)

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,7 +114,7 @@ Now, you can use *batch_scorer* for eRAG.
 - **--retrieval_metrics**: This is a set of retrieval metric names that eRAG uses to aggregate the scores of individual documents in a ranked list for each query. We follow the [*pytrec_eval*](https://github.com/cvangysel/pytrec_eval) format for naming metrics. Note that when the returned values by *downstream_metric* are not binary (zero and one), the only possible metrics are precision ('P') and Hit Ratio ('success'). e.g., 
 
 ```
-retrieval_metrics = {'P_10', 'success', 'recall', 'map'}
+retrieval_metrics = {'P_10', 'success'}
 ```
 
 

--- a/erag/eval.py
+++ b/erag/eval.py
@@ -1,49 +1,56 @@
-from typing import Dict, Callable, List, Union, Set
+from typing import Callable, Dict, List, Set, Union
+
 import pytrec_eval
-import json
+
 
 def eval(
-        retrieval_results : Dict[str, List[str]], 
-        expected_outputs : Dict[str, List[str]], 
-        text_generator: Callable[[Dict[str, List[str]]], Dict[str, str]],
-        downstream_metric: Callable[[Dict[str, str], Dict[str, List[str]]], Dict[str, Union[int, float]]],
-        retrieval_metrics: Set[str],
-        **args,
-    ):
+    retrieval_results: Dict[str, List[str]],
+    expected_outputs: Dict[str, List[str]],
+    text_generator: Callable[[Dict[str, List[str]]], Dict[str, str]],
+    downstream_metric: Callable[
+        [Dict[str, str], Dict[str, List[str]]], Dict[str, Union[int, float]]
+    ],
+    retrieval_metrics: Set[str],
+    **args,
+):
     """
     This function returns the eRAG score as explained in "[link to paper]"
 
     Args:
         retrieval_results ('Dict[str, List[str]]'):
-            A dictionary that the key is the text input and the value is a list of 
+            A dictionary that the key is the text input and the value is a list of
             retrieval results in 'str' format that should be evaluated.
-        
+
         expected_outputs ('Dict[str, List[str]]'):
             A dictionary that the key is the text input and the value is a list of the expected
             output that the 'text_generator' function should generate for that input.
-                    
+
         text_generator ('Callable[[Dict[str, List[str]]], Dict[str, str]]'):
-            A callable object that takes a dictionary of textual input to retrieval list and 
+            A callable object that takes a dictionary of textual input to retrieval list and
             generates dictionary of textual input to corresponding output.
-                    
+
         downstream_metric ('Callable[[Dict[str, str], Dict[str, List[str]]], Dict[str, Union[int, float]]]'):
-            A callable object that takes a dictonary of textual inputs to the corresponding prediction text as the first argument 
+            A callable object that takes a dictonary of textual inputs to the corresponding prediction text as the first argument
             and a dictionary of the textual inputs to corresponding list of gold outputs as the second argument,
             and generates a score based on them for the prediction text. The generated score should be in range [0, 1].
 
         retrieval_metrics ('Set[str]'):
-            The set of Information Retrieval metrics should be used to evaluate the retrieval results. 
+            The set of Information Retrieval metrics should be used to evaluate the retrieval results.
             We follow the same format as pytrec_eval library for deifning metrics: "https://github.com/cvangysel/pytrec_eval"
-    
+
     Returns:
         A dictionary containing the per input eRAG score the and aggregated eRAG score.
     """
 
-    assert set(retrieval_results.keys()) == set(expected_outputs.keys()), 'The keys in retrieval results and expected outputs do not match.'
+    assert set(retrieval_results.keys()) == set(
+        expected_outputs.keys()
+    ), "The keys in retrieval results and expected outputs do not match."
 
     max_length_retrieval_lists = max(len(lst) for lst in retrieval_results.values())
     flatten_inputs = {
-        f'{query}@{i}' : {'query' : query, 'document' : [doc]} for query, documents in retrieval_results.items() for i, doc in enumerate(documents)
+        f"{query}@{i}": {"query": query, "document": [doc]}
+        for query, documents in retrieval_results.items()
+        for i, doc in enumerate(documents)
     }
 
     evaluation_scores = dict()
@@ -52,17 +59,23 @@ def eval(
         current_input = dict()
         current_expected_outputs = dict()
         for query in retrieval_results.keys():
-            if f'{query}@{i}' in flatten_inputs.keys():
-                item = flatten_inputs[f'{query}@{i}']
-                current_input[item['query']] = item['document']
-                current_expected_outputs[item['query']] = expected_outputs[item['query']]
+            if f"{query}@{i}" in flatten_inputs.keys():
+                item = flatten_inputs[f"{query}@{i}"]
+                current_input[item["query"]] = item["document"]
+                current_expected_outputs[item["query"]] = expected_outputs[item["query"]]
         current_generated_outputs = text_generator(current_input)
-        assert set(current_input.keys()) == set(current_generated_outputs.keys()), 'The text_generator function did not return outputs for all given inputs.'
-        current_evaluation_scores = downstream_metric(current_generated_outputs, current_expected_outputs)
-        assert set(current_generated_outputs.keys()) == set(current_evaluation_scores.keys()), 'The downstream_metric function did not return evaluation scores for all given inputs.'
+        assert set(current_input.keys()) == set(
+            current_generated_outputs.keys()
+        ), "The text_generator function did not return outputs for all given inputs."
+        current_evaluation_scores = downstream_metric(
+            current_generated_outputs, current_expected_outputs
+        )
+        assert set(current_generated_outputs.keys()) == set(
+            current_evaluation_scores.keys()
+        ), "The downstream_metric function did not return evaluation scores for all given inputs."
         for query, score in current_evaluation_scores.items():
-            evaluation_scores[f'{query}@{i}'] = score
-    
+            evaluation_scores[f"{query}@{i}"] = score
+
     qrel = dict()
     run = dict()
 
@@ -73,15 +86,17 @@ def eval(
         qrel[query] = dict()
         for j in range(len(retrieval_results[query])):
             run[query][str(j)] = len(retrieval_results[query]) - j
-            qrel[query][str(j)] = evaluation_scores[f'{query}@{j}']
-            
+            qrel[query][str(j)] = evaluation_scores[f"{query}@{j}"]
+
             if qrel[query][str(j)] in [0, 1]:
                 qrel[query][str(j)] = int(qrel[query][str(j)])
             if qrel[query][str(j)] not in [0, 1]:
                 binary_downstream_metric = False
             if qrel[query][str(j)] > 1 or qrel[query][str(j)] < 0:
-                raise RuntimeError('The returning value of the downstream_metric must be in range [0,1].')
-            
+                raise RuntimeError(
+                    "The returning value of the downstream_metric must be in range [0,1]."
+                )
+
     if binary_downstream_metric:
         evaluator = pytrec_eval.RelevanceEvaluator(qrel, retrieval_metrics)
         results = evaluator.evaluate(run)
@@ -91,31 +106,33 @@ def eval(
             results[query] = dict()
             for metric in retrieval_metrics:
                 if "_" in metric:
-                    metric_without_cut = metric[:metric.find("_")]
-                    if metric_without_cut not in {'success', 'P'}:
-                        raise RuntimeError('The provided retrieval metrics cannot be used with continuous downsream metric. The supported retrieval metrics are ["success", "P"]')
-                    cut_value = int(metric[metric.find("_")+1:])
+                    metric_without_cut = metric[: metric.find("_")]
+                    if metric_without_cut not in {"success", "P"}:
+                        raise RuntimeError(
+                            'The provided retrieval metrics cannot be used with continuous downstream metric. The supported retrieval metrics are ["success", "P"]'
+                        )
+                    cut_value = int(metric[metric.find("_") + 1 :])
                 else:
                     metric_without_cut = metric
                     cut_value = len(labels)
-                if metric_without_cut == 'success':
+                if metric_without_cut == "success":
                     max_value = 0
                     for i in range(cut_value):
                         max_value = max(max_value, labels[str(i)])
                     results[query][metric] = max_value
-                elif metric_without_cut == 'P':
+                elif metric_without_cut == "P":
                     mean_value = 0
+                    if cut_value > len(labels):
+                        cut_value = len(labels)
                     for i in range(cut_value):
                         mean_value += labels[str(i)]
                     results[query][metric] = mean_value / cut_value
                 else:
-                    raise RuntimeError('The provided retrieval metrics cannot be used with continuous downsream metric. The supported retrieval metrics are ["success", "P"]')
-    final_results = {'per_input' : results, 'aggregated' : dict()}
+                    raise RuntimeError(
+                        'The provided retrieval metrics cannot be used with continuous downstream metric. The supported retrieval metrics are ["success", "P"]'
+                    )
+    final_results = {"per_input": results, "aggregated": dict()}
     for metric in retrieval_metrics:
         values = [value[metric] for key, value in results.items()]
-        final_results['aggregated'][metric] = sum(values) / len(values)
+        final_results["aggregated"][metric] = sum(values) / len(values)
     return final_results
-
-
-
-    


### PR DESCRIPTION
## Summary
Fixes a boundary check bug in the evaluation logic and updates documentation to match supported metrics.

## Changes
1. **Bug fix:** boundary check for cut_value (commit 08f97bf)
Added a check to cap cut_value to len(labels) when computing precision metrics for continuous downstream metrics
Prevents index errors when cut_value exceeds the number of available labels
Code formatting improvements (black formatting)
_Location_: erag/eval.py lines 122-124
2. **Documentation update** (commit 86ab015)
Updated README.md to remove unsupported metrics (recall, map) from the example
Kept only supported metrics (P_*, success) for continuous downstream metrics
_Location_: README.md line 117

## Testing
Verify that precision metrics work correctly when cut_value > len(labels) (not included)
Confirm that examples in the README use only supported metrics

## Impact
**Bug fix**: prevents runtime errors when evaluating retrieval results with fewer documents than the requested cut-off (which are stated in https://github.com/alirezasalemi7/eRAG/issues/1)
**Documentation**: clarifies which metrics are supported for continuous downstream metrics (which are stated in https://github.com/alirezasalemi7/eRAG/issues/2)

These changes improve robustness and user experience.